### PR TITLE
wait time calculation error with usleep() #489

### DIFF
--- a/os.c
+++ b/os.c
@@ -499,7 +499,7 @@ public void sleep_ms(int ms)
 	nanosleep(&t, NULL);
 #else
 #if HAVE_USLEEP
-	usleep(ms);
+	usleep(ms * 1000);
 #else
 	sleep(ms / 1000 + (ms % 1000 != 0));
 #endif


### PR DESCRIPTION
fix usleep() parameter value from milliseconds to microseconds

see #489